### PR TITLE
Modify hooks

### DIFF
--- a/contracts/bridge/Controller.sol
+++ b/contracts/bridge/Controller.sol
@@ -27,7 +27,7 @@ contract Controller is Base {
         address connector_,
         bytes calldata execPayload_,
         bytes calldata options_
-    ) external payable nonReentrant {
+    ) external payable {
         (
             TransferInfo memory transferInfo,
             bytes memory postHookData

--- a/contracts/hooks/KintoHook.sol
+++ b/contracts/hooks/KintoHook.sol
@@ -26,7 +26,7 @@ contract KintoHook is LimitHook {
     IKintoFactory public immutable kintoFactory;
 
     // if withdrawalAmount > 0, will trigger a withdrawal back to the vault chain
-    uint256 withdrawalAmount;
+    uint256 public withdrawalAmount;
 
     error InvalidSender(address sender);
     error ReceiverNotAllowed(address receiver);

--- a/contracts/hooks/LimitHook.sol
+++ b/contracts/hooks/LimitHook.sol
@@ -40,7 +40,7 @@ contract LimitHook is LimitPlugin, ConnectorPoolPlugin {
 
     function srcPostHookCall(
         SrcPostHookCallParams memory params_
-    ) public view virtual isVaultOrController returns (TransferInfo memory) {
+    ) public virtual isVaultOrController returns (TransferInfo memory) {
         return params_.transferInfo;
     }
 

--- a/contracts/hooks/SenderHook.sol
+++ b/contracts/hooks/SenderHook.sol
@@ -10,7 +10,7 @@ import "./LimitHook.sol";
 contract SenderHook is LimitHook {
     /**
      * @notice meant to be deployed only on vault chains (all except Kinto).
-     * Overrides `srcPreHookCall` to pass the `msg.sender` so that it can be used 
+     * Overrides `srcPreHookCall` to pass the `msg.sender` so that it can be used
      * in the `dstPreHookCall` on Kinto chain.
      * @param owner_ Owner of this contract.
      * @param controller_ Controller of this contract.
@@ -39,7 +39,7 @@ contract SenderHook is LimitHook {
 
     function srcPostHookCall(
         SrcPostHookCallParams memory params_
-    ) public view override isVaultOrController returns (TransferInfo memory) {
+    ) public override isVaultOrController returns (TransferInfo memory) {
         return super.srcPostHookCall(params_);
     }
 

--- a/test/hooks/kintoHook.t.sol
+++ b/test/hooks/kintoHook.t.sol
@@ -56,7 +56,6 @@ contract TestKintoHook is Test {
     bytes32 constant LIMIT_UPDATER_ROLE = keccak256("LIMIT_UPDATER_ROLE");
 
     function setUp() external {
-        
         uint256 kintoFork = vm.createSelectFork("kinto_devnet");
 
         vm.startPrank(_admin);
@@ -70,7 +69,13 @@ contract TestKintoHook is Test {
         _siblingSlug1 = uint32(_c++);
         _siblingSlug2 = uint32(_c++);
 
-        kintoHook__ = new KintoHook(_admin, controller__, false, kintoId__, kintoFactory__);
+        kintoHook__ = new KintoHook(
+            _admin,
+            controller__,
+            false,
+            kintoId__,
+            kintoFactory__
+        );
         _token = new MintableToken("Moon", "MOON", 18);
         _token.mint(_admin, _initialSupply);
         _token.mint(_raju, _rajuInitialBal);
@@ -156,7 +161,9 @@ contract TestKintoHook is Test {
 
         vm.startPrank(controller__);
 
-        vm.expectRevert(abi.encodeWithSelector(KintoHook.InvalidSender.selector, sender));
+        vm.expectRevert(
+            abi.encodeWithSelector(KintoHook.InvalidSender.selector, sender)
+        );
         kintoHook__.srcPreHookCall(
             SrcPreHookCallParams(
                 _connector1,
@@ -208,7 +215,12 @@ contract TestKintoHook is Test {
 
         vm.startPrank(controller__);
 
-        vm.expectRevert(abi.encodeWithSelector(KintoHook.ReceiverNotAllowed.selector, receiver));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                KintoHook.ReceiverNotAllowed.selector,
+                receiver
+            )
+        );
         kintoHook__.srcPreHookCall(
             SrcPreHookCallParams(
                 _connector1,
@@ -275,7 +287,6 @@ contract TestKintoHook is Test {
     }
 
     ////// FINISH: KintoHook:srcPreHook tests //////
-
 
     function testsrcPreHookCallSender() external {
         _setLimits();
@@ -427,7 +438,9 @@ contract TestKintoHook is Test {
         address sender = kintoWalletSigner__; // original sender from vault chain
         address receiver = address(0xfede);
 
-        vm.expectRevert(abi.encodeWithSelector(KintoHook.InvalidReceiver.selector, receiver));
+        vm.expectRevert(
+            abi.encodeWithSelector(KintoHook.InvalidReceiver.selector, receiver)
+        );
         vm.startPrank(controller__);
         (
             bytes memory postHookData,
@@ -471,7 +484,9 @@ contract TestKintoHook is Test {
         address sender = address(0xfede); // original sender from vault chain
         address receiver = kintoWallet__;
 
-        vm.expectRevert(abi.encodeWithSelector(KintoHook.SenderNotAllowed.selector, sender));
+        vm.expectRevert(
+            abi.encodeWithSelector(KintoHook.SenderNotAllowed.selector, sender)
+        );
         vm.startPrank(controller__);
         (
             bytes memory postHookData,

--- a/test/hooks/senderHook.t.sol
+++ b/test/hooks/senderHook.t.sol
@@ -228,7 +228,7 @@ contract TestSenderHook is Test {
     }
 
     ////// START: SenderHook:srcPreHook tests //////
-    
+
     function testsrcPreHookCallStoresMsgSender() external {
         _setLimits();
         uint256 withdrawAmount = 10 ether;
@@ -270,7 +270,11 @@ contract TestSenderHook is Test {
         assertEq(_raju, transferInfo.receiver, "receiver incorrect");
         assertEq(withdrawAmount, transferInfo.amount, "amount incorrect");
         assertEq(transferInfo.data, payload, "extra data incorrect");
-        assertEq(abi.decode(transferInfo.data, (address)), sender, "msgSender not stored");
+        assertEq(
+            abi.decode(transferInfo.data, (address)),
+            sender,
+            "msgSender not stored"
+        );
     }
 
     ////// END: SenderHook:srcPreHook tests //////


### PR DESCRIPTION
This PR covers the case in which a user tries bridging from other chains to Kinto and a Kinto checks fails, so, instead of reverting, we trigger a withdrawal.

Upside of this approach: we don't have to be rescuing funds from and manually sending them to the users. The withdrawal back to the user happens automatically.

Downside: this withdrawals need to pay gas for their execution. And the hook needs to pay for them. We need to keep some ETH on the hook contract for this run.

In any case, we should make the checks on the UI to prevent that these scenarios get to the contracts.