### PR TITLE
Modify KintoHook

### DIFF
--- a/contracts/hooks/KintoHook.sol
+++ b/contracts/hooks/KintoHook.sol
@@ -32,7 +32,6 @@ contract KintoHook is LimitHook {
     error InvalidSender(address sender);
     error InvalidReceiver(address sender);
     error KYCRequired();
-    error ReceiverNotAllowed(address receiver);
     error SenderNotAllowed(address sender);
 
     event SenderSet(address indexed sender, bool allowed);
@@ -81,10 +80,6 @@ contract KintoHook is LimitHook {
         if (kintoFactory.walletTs(sender) == 0) revert InvalidSender(sender);
         if (!kintoID.isKYC(IKintoWallet(sender).owners(0)))
             revert KYCRequired();
-
-        address receiver = params_.transferInfo.receiver;
-        if (!IKintoWallet(sender).isFunderWhitelisted(receiver))
-            revert ReceiverNotAllowed(receiver);
 
         return super.srcPreHookCall(params_);
     }

--- a/test/hooks/kintoHook.t.sol
+++ b/test/hooks/kintoHook.t.sol
@@ -204,35 +204,6 @@ contract TestKintoHook is Test {
         vm.stopPrank();
     }
 
-    function testsrcPreHookCallReceiverNotAllowed() external {
-        _setLimits();
-
-        uint256 withdrawAmount = 10 ether;
-        uint256 dealAmount = 10 ether;
-        address sender = kintoWallet__;
-        address receiver = address(0xfede);
-
-        deal(address(_token), sender, dealAmount);
-        deal(sender, _fees);
-
-        vm.startPrank(controller__);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                KintoHook.ReceiverNotAllowed.selector,
-                receiver
-            )
-        );
-        kintoHook__.srcPreHookCall(
-            SrcPreHookCallParams(
-                _connector1,
-                address(sender),
-                TransferInfo(receiver, withdrawAmount, bytes(""))
-            )
-        );
-        vm.stopPrank();
-    }
-
     function testsrcPreHookCallReceiverIsKintoWalletSigner() external {
         _setLimits();
 


### PR DESCRIPTION
This PR modifies the `KintoHook` to allow privileged addresses to bypass the `isFunderWhitelisted` when bridging from other chains into Kinto. 

It adds a `senderAllowlist` mapping and a setter function. If the sender is in the allowlist, it bypasses the check.
This is useful, for example, for allowing Kinto's `Bridger` contracts deployed on Ethereum, Arbitrum and Base. 